### PR TITLE
add env to npm test to fix error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ let server = app.listen(8080);
 console.log('Server running in port: 8080 ...');
 
 module.exports = server;
-module.exports.stop = async (done) => {
-    await server.close();
+module.exports.stop = (done) => {
+    server.close();
     done();
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "env NODE_ENV=test mocha --timeout 10000 --require @babel/register 'test/**/**Spec.js'"
+    "test": "env NODE_ENV=test ./node_modules/mocha/bin/mocha --timeout 10000 --require @babel/register 'test/**/**Spec.js'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "NODE_ENV=test mocha --timeout 10000 --require @babel/register 'test/**/**Spec.js'"
+    "test": "env NODE_ENV=test mocha --timeout 10000 --require @babel/register 'test/**/**Spec.js'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
adding 'env' to the beginning of the npm test command allows others on
a windows operating systems to run this project without problems and
removing async and await is because of a error caused by adding 'env'