### PR TITLE
Make get-seats-for-flight endpoint return more data

### DIFF
--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -7,8 +7,8 @@ function booleanConvertingWrapper(cb) {
         if (err) {
             cb(err, result);
         } else {
-            for (record of result) {
-                for (key in record) {
+            for (var record of result) {
+                for (var key in record) {
                     if (record[key] === 'true') {
                         record[key] = true;
                     } else if (record[key] === 'false') {
@@ -20,7 +20,7 @@ function booleanConvertingWrapper(cb) {
             }
             cb(err, result);
         }
-    }
+    };
 }
 
 exports.get = function(filter, cb) {

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -9,10 +9,10 @@ function booleanConvertingWrapper(cb) {
             return;
         } 
         for (var record of result) {
-            if (record['reserved'] === 'true') {
-                record['reserved'] = true;
-            } else if (record['reserved'] === 'false') {
-                record['reserved'] = false;
+            if (record.reserved === 'true') {
+                record.reserved = true;
+            } else if (record.reserved === 'false') {
+                record.reserved = false;
             }
         }
         cb(err, result);

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -9,12 +9,10 @@ function booleanConvertingWrapper(cb) {
             return;
         } 
         for (var record of result) {
-            for (var key in record) {
-                if (record[key] === 'true') {
-                    record[key] = true;
-                } else if (record[key] === 'false') {
-                    record[key] = false;
-                }
+            if (record['reserved'] === 'true') {
+                record['reserved'] = true;
+            } else if (record['reserved'] === 'false') {
+                record['reserved'] = false;
             }
         }
         cb(err, result);

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -14,8 +14,6 @@ function booleanConvertingWrapper(cb) {
                     record[key] = true;
                 } else if (record[key] === 'false') {
                     record[key] = false;
-                } else if (key === 'reserved') {
-                    console.log(record);
                 }
             }
         }

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -6,20 +6,20 @@ function booleanConvertingWrapper(cb) {
     return function(err, result) {
         if (err) {
             cb(err, result);
-        } else {
-            for (var record of result) {
-                for (var key in record) {
-                    if (record[key] === 'true') {
-                        record[key] = true;
-                    } else if (record[key] === 'false') {
-                        record[key] = false;
-                    } else if (key === 'reserved') {
-                        console.log(record);
-                    }
+            return;
+        } 
+        for (var record of result) {
+            for (var key in record) {
+                if (record[key] === 'true') {
+                    record[key] = true;
+                } else if (record[key] === 'false') {
+                    record[key] = false;
+                } else if (key === 'reserved') {
+                    console.log(record);
                 }
             }
-            cb(err, result);
         }
+        cb(err, result);
     };
 }
 

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -2,8 +2,29 @@ const flightNumberFilter = require('../util/flightNumberFilter');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
 
+function booleanConvertingWrapper(cb) {
+    return function(err, result) {
+        if (err) {
+            cb(err, result);
+        } else {
+            for (record of result) {
+                for (key in record) {
+                    if (record[key] === 'true') {
+                        record[key] = true;
+                    } else if (record[key] === 'false') {
+                        record[key] = false;
+                    } else if (key === 'reserved') {
+                        console.log(record);
+                    }
+                }
+            }
+            cb(err, result);
+        }
+    }
+}
+
 exports.get = function(filter, cb) {
-    let sqlQuery = 'SELECT seat_row, seat FROM tbl_tickets AS t LEFT JOIN tbl_flights AS f ON t.flight = f.id WHERE f.flight_number = ' +
+    let sqlQuery = 'SELECT seat_row, seat, class, CASE WHEN reserver IS NULL THEN \'false\' ELSE \'true\' END AS reserved FROM tbl_tickets AS t LEFT JOIN tbl_flights AS f ON t.flight = f.id WHERE f.flight_number = ' +
         flightNumberFilter(filter.flight, db) + ';';
-    dbConn.query(sqlQuery, cb);
+    dbConn.query(sqlQuery, booleanConvertingWrapper(cb));
 };


### PR DESCRIPTION
Specifically, the seat class and whether it is reserved as well as its coordinates.

By the API definition we should also return the flight (object), but
as that would require another SELECT I'll postpone that to another
PR.

This should fix utopia-airlines/UtopiaAirlinesCounterAPI#8 and utopia-airlines/UtopiaAirlinesAgentAPI#20, at least enough for the time being.