### PR TITLE
Update dotenv dependency to latest version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -655,9 +655,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mysql": "^2.17.1",
     "express": "^4.17.1",
     "body-parser": "^1.18.2",
-    "dotenv": "^8.0.0",
+    "dotenv": "^8.1.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
As far as I can see there's no known security issue with the older version, but on general principles a newer version is to be preferred if it will function as well as the older. I have *not* tested this against a live database, only via `npm test`.