### PR TITLE
Return full objects, not only codes or numbers, per API spec

### DIFF
--- a/app/dao/flightDetailDao.js
+++ b/app/dao/flightDetailDao.js
@@ -12,7 +12,7 @@ const baseQuery = `SELECT departure_airport.code AS departure_code,
                     LEFT JOIN tbl_airports departure_airport
                         ON tbl_flights.departure = departure_airport.code
                     LEFT JOIN tbl_airports destination_airport
-                        ON tbl_flights.destination = destination_airport.code`
+                        ON tbl_flights.destination = destination_airport.code`;
 
 exports.get = function(filter, cb) {
     let sqlQuery = `${baseQuery}

--- a/app/dao/flightDetailDao.js
+++ b/app/dao/flightDetailDao.js
@@ -1,34 +1,7 @@
 const flightNumberFilter = require('../util/flight_numberFilter');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
-
-function deleteMultiple(obj, ...names) {
-    for (var name of names) {
-        delete obj[name];
-    }
-}
-
-function nestAirportsWrapper(cb) {
-    return function(err, result) {
-        if (err) {
-            cb(err, result);
-            return;
-        }
-        for (var record of result) {
-            record.departure = {
-                code: record.departure_code,
-                name: record.departure_name
-            };
-            record.destination = {
-                code: record.destination_code,
-                name: record.destination_name
-            };
-            deleteMultiple(record, 'departure_code', 'departure_name',
-                'destination_code', 'destination_name');
-        }
-        cb(err, result);
-    };
-}
+const nestAirportsWrapper = require('../util/nestAirportsWrapper');
 
 exports.get = function(filter, cb) {
     let sqlQuery = `SELECT departure_airport.code AS departure_code,

--- a/app/dao/flightDetailDao.js
+++ b/app/dao/flightDetailDao.js
@@ -2,6 +2,12 @@ const flightNumberFilter = require('../util/flight_numberFilter');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
 
+function deleteMultiple(obj, ...names) {
+    for (var name of names) {
+        delete obj[name];
+    }
+}
+
 function nestAirportsWrapper(cb) {
     return function(err, result) {
         if (err) {
@@ -17,10 +23,8 @@ function nestAirportsWrapper(cb) {
                 code: record.destination_code,
                 name: record.destination_name
             };
-            delete record.departure_code;
-            delete record.departure_name;
-            delete record.destination_code;
-            delete record.destination_name;
+            deleteMultiple(record, 'departure_code', 'departure_name',
+                'destination_code', 'destination_name');
         }
         cb(err, result);
     };

--- a/app/dao/flightDetailDao.js
+++ b/app/dao/flightDetailDao.js
@@ -1,17 +1,57 @@
 const flightNumberFilter = require('../util/flight_numberFilter');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
+
+function nestAirportsWrapper(cb) {
+    return function(err, result) {
+        if (err) {
+            cb(err, result);
+            return;
+        }
+        for (var record of result) {
+            record.departure = {
+                code: record.departure_code,
+                name: record.departure_name
+            };
+            record.destination = {
+                code: record.destination_code,
+                name: record.destination_name
+            };
+            delete record.departure_code;
+            delete record.departure_name;
+            delete record.destination_code;
+            delete record.destination_name;
+        }
+        cb(err, result);
+    };
+}
+
 exports.get = function(filter, cb) {
-    let sqlQuery = `SELECT departure, destination, departure_date, arrival_date,
-                            flight_number
+    let sqlQuery = `SELECT departure_airport.code AS departure_code,
+                            departure_airport.name AS departure_name,
+                            destination_airport.code AS destination_code,
+                            destination_airport.name AS destination_name,
+                            departure_date, arrival_date, flight_number
                         FROM tbl_flights
+                        LEFT JOIN tbl_airports departure_airport
+                            ON tbl_flights.departure = departure_airport.code
+                        LEFT JOIN tbl_airports destination_airport
+                            ON tbl_flights.destination = destination_airport.code
                         WHERE flight_number = ${flightNumberFilter(filter.flight, db)}
                         ;`;
-    dbConn.query(sqlQuery, cb);
+    dbConn.query(sqlQuery, nestAirportsWrapper(cb));
 };
 
 exports.getAll = (cb) => {
-    let sqlQuery = `SELECT departure, destination, departure_date, arrival_date,
-                        flight_number FROM tbl_flights;`;
-    dbConn.query(sqlQuery, cb);
+    let sqlQuery = `SELECT departure_airport.code AS departure_code,
+                        departure_airport.name AS departure_name,
+                        destination_airport.code AS destination_code,
+                        destination_airport.name AS destination_name,
+                        departure_date, arrival_date, flight_number
+                        FROM tbl_flights
+                        LEFT JOIN tbl_airports departure_airport
+                            ON tbl_flights.departure = departure_airport.code
+                        LEFT JOIN tbl_airports destination_airport
+                            ON tbl_flights.destination = destination_airport.code;`;
+    dbConn.query(sqlQuery, nestAirportsWrapper(cb));
 };

--- a/app/dao/flightDetailDao.js
+++ b/app/dao/flightDetailDao.js
@@ -3,32 +3,24 @@ const dbConn = require('./db');
 const db = require('../config/db.config.prod');
 const nestAirportsWrapper = require('../util/nestAirportsWrapper');
 
+const baseQuery = `SELECT departure_airport.code AS departure_code,
+                        departure_airport.name AS departure_name,
+                        destination_airport.code AS destination_code,
+                        destination_airport.name AS destination_name,
+                        departure_date, arrival_date, flight_number
+                    FROM tbl_flights
+                    LEFT JOIN tbl_airports departure_airport
+                        ON tbl_flights.departure = departure_airport.code
+                    LEFT JOIN tbl_airports destination_airport
+                        ON tbl_flights.destination = destination_airport.code`
+
 exports.get = function(filter, cb) {
-    let sqlQuery = `SELECT departure_airport.code AS departure_code,
-                            departure_airport.name AS departure_name,
-                            destination_airport.code AS destination_code,
-                            destination_airport.name AS destination_name,
-                            departure_date, arrival_date, flight_number
-                        FROM tbl_flights
-                        LEFT JOIN tbl_airports departure_airport
-                            ON tbl_flights.departure = departure_airport.code
-                        LEFT JOIN tbl_airports destination_airport
-                            ON tbl_flights.destination = destination_airport.code
+    let sqlQuery = `${baseQuery}
                         WHERE flight_number = ${flightNumberFilter(filter.flight, db)}
                         ;`;
     dbConn.query(sqlQuery, nestAirportsWrapper(cb));
 };
 
 exports.getAll = (cb) => {
-    let sqlQuery = `SELECT departure_airport.code AS departure_code,
-                        departure_airport.name AS departure_name,
-                        destination_airport.code AS destination_code,
-                        destination_airport.name AS destination_name,
-                        departure_date, arrival_date, flight_number
-                        FROM tbl_flights
-                        LEFT JOIN tbl_airports departure_airport
-                            ON tbl_flights.departure = departure_airport.code
-                        LEFT JOIN tbl_airports destination_airport
-                            ON tbl_flights.destination = destination_airport.code;`;
-    dbConn.query(sqlQuery, nestAirportsWrapper(cb));
+    dbConn.query(`${baseQuery};`, nestAirportsWrapper(cb));
 };

--- a/app/dao/searchDao.js
+++ b/app/dao/searchDao.js
@@ -1,13 +1,24 @@
 const allFilters = require('./allFilters');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
+const nestAirportsWrapper = require('../util/nestAirportsWrapper');
+const nestFlightWrapper = require('../util/nestFlightWrapper');
+
 exports.get = function(filter, cb) {
     // filter out non-NULL reserver by default because we want tickets that
     // have not been taken yet
-    let sqlQuery = `SELECT seat_row, seat, class, departure, destination,
+    let sqlQuery = `SELECT seat_row, seat, class,
+                            departure_airport.code AS departure_code,
+                            departure_airport.name AS departure_name,
+                            destination_airport.code AS destination_code,
+                            destination_airport.name AS destination_name,
                             departure_date, arrival_date, flight_number
                         FROM tbl_tickets AS t
                         LEFT JOIN tbl_flights AS f ON t.flight = f.id
+                        LEFT JOIN tbl_airports departure_airport
+                            ON f.departure = departure_airport.code
+                        LEFT JOIN tbl_airports destination_airport
+                            ON f.destination = destination_airport.code
                         WHERE reserver IS NULL
                             ${allFilters.classFilter(filter.class, db)}
                             ${allFilters.seatFilter(filter.seat, db)}
@@ -16,5 +27,5 @@ exports.get = function(filter, cb) {
                             ${allFilters.departureLocationFilter(filter.departure_location, db)}
                             ${allFilters.destinationLocationFilter(filter.destination_location, db)}
                         ;`;
-    dbConn.query(sqlQuery, cb);
+    dbConn.query(sqlQuery, nestFlightWrapper(nestAirportsWrapper(cb)));
 };

--- a/app/dao/searchDao.js
+++ b/app/dao/searchDao.js
@@ -3,16 +3,12 @@ const dbConn = require('./db');
 const db = require('../config/db.config.prod');
 const nestAirportsWrapper = require('../util/nestAirportsWrapper');
 const nestFlightWrapper = require('../util/nestFlightWrapper');
+const seatFields = require('./seatFields');
 
 exports.get = function(filter, cb) {
     // filter out non-NULL reserver by default because we want tickets that
     // have not been taken yet
-    let sqlQuery = `SELECT seat_row, seat, class,
-                            departure_airport.code AS departure_code,
-                            departure_airport.name AS departure_name,
-                            destination_airport.code AS destination_code,
-                            destination_airport.name AS destination_name,
-                            departure_date, arrival_date, flight_number
+    let sqlQuery = `SELECT ${seatFields}
                         FROM tbl_tickets AS t
                         LEFT JOIN tbl_flights AS f ON t.flight = f.id
                         LEFT JOIN tbl_airports departure_airport

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -3,6 +3,7 @@ const dbConn = require('./db');
 const db = require('../config/db.config.prod');
 const nestAirportsWrapper = require('../util/nestAirportsWrapper');
 const nestFlightWrapper = require('../util/nestFlightWrapper');
+const seatFields = require('./seatFields');
 
 function booleanConvertingWrapper(cb) {
     return function(err, result) {
@@ -22,12 +23,7 @@ function booleanConvertingWrapper(cb) {
 }
 
 exports.get = function(filter, cb) {
-    let sqlQuery = `SELECT seat_row, seat, class,
-                        departure_airport.code AS departure_code,
-                        departure_airport.name AS departure_name,
-                        destination_airport.code AS destination_code,
-                        destination_airport.name AS destination_name,
-                        departure_date, arrival_date, flight_number,
+    let sqlQuery = `SELECT ${seatFields},
                         CASE WHEN reserver IS NULL THEN 'false' ELSE 'true' END
                             AS reserved
                         FROM tbl_tickets AS t

--- a/app/dao/seatDetailDao.js
+++ b/app/dao/seatDetailDao.js
@@ -1,6 +1,8 @@
 const flightNumberFilter = require('../util/flightNumberFilter');
 const dbConn = require('./db');
 const db = require('../config/db.config.prod');
+const nestAirportsWrapper = require('../util/nestAirportsWrapper');
+const nestFlightWrapper = require('../util/nestFlightWrapper');
 
 function booleanConvertingWrapper(cb) {
     return function(err, result) {
@@ -21,11 +23,20 @@ function booleanConvertingWrapper(cb) {
 
 exports.get = function(filter, cb) {
     let sqlQuery = `SELECT seat_row, seat, class,
+                        departure_airport.code AS departure_code,
+                        departure_airport.name AS departure_name,
+                        destination_airport.code AS destination_code,
+                        destination_airport.name AS destination_name,
+                        departure_date, arrival_date, flight_number,
                         CASE WHEN reserver IS NULL THEN 'false' ELSE 'true' END
                             AS reserved
                         FROM tbl_tickets AS t
                         LEFT JOIN tbl_flights AS f ON t.flight = f.id
+                        LEFT JOIN tbl_airports departure_airport
+                            ON f.departure = departure_airport.code
+                        LEFT JOIN tbl_airports destination_airport
+                            ON f.destination = destination_airport.code
                         WHERE f.flight_number = ${flightNumberFilter(filter.flight, db)}
                         ;`;
-    dbConn.query(sqlQuery, booleanConvertingWrapper(cb));
+    dbConn.query(sqlQuery, nestFlightWrapper(nestAirportsWrapper(booleanConvertingWrapper(cb))));
 };

--- a/app/dao/seatFields.js
+++ b/app/dao/seatFields.js
@@ -1,0 +1,6 @@
+// Common SQL columns requested by both the search DAO and the seat-detail DAO.
+module.exports = `seat_row, seat, class, departure_airport.code AS departure_code,
+                departure_airport.name AS departure_name,
+                destination_airport.code AS destination_name,
+                destination_airport.name AS destination_name, departure_date,
+                arrival_date, flight_number`;

--- a/app/util/deleteMultiple.js
+++ b/app/util/deleteMultiple.js
@@ -1,0 +1,5 @@
+module.exports = function(obj, ...names) {
+    for (var name of names) {
+        delete obj[name];
+    }
+};

--- a/app/util/nestAirportsWrapper.js
+++ b/app/util/nestAirportsWrapper.js
@@ -1,21 +1,21 @@
 const deleteMultiple = require('./deleteMultiple');
 
+function helper(obj, key) {
+    obj[key] = {
+        code: obj[key + '_code'],
+        name: obj[key + '_name']
+    };
+    deleteMultiple(obj, key + '_code', key + '_name');
+}
+
 module.exports = (cb) => function(err, result) {
     if (err) {
         cb(err, result);
         return;
     }
     for (var record of result) {
-        record.departure = {
-            code: record.departure_code,
-            name: record.departure_name
-        };
-        record.destination = {
-            code: record.destination_code,
-            name: record.destination_name
-        };
-        deleteMultiple(record, 'departure_code', 'departure_name',
-            'destination_code', 'destination_name');
+        helper(record, 'departure');
+        helper(record, 'destination');
     }
     cb(err, result);
 };

--- a/app/util/nestAirportsWrapper.js
+++ b/app/util/nestAirportsWrapper.js
@@ -1,0 +1,21 @@
+const deleteMultiple = require('./deleteMultiple');
+
+module.exports = (cb) => function(err, result) {
+    if (err) {
+        cb(err, result);
+        return;
+    }
+    for (var record of result) {
+        record.departure = {
+            code: record.departure_code,
+            name: record.departure_name
+        };
+        record.destination = {
+            code: record.destination_code,
+            name: record.destination_name
+        };
+        deleteMultiple(record, 'departure_code', 'departure_name',
+            'destination_code', 'destination_name');
+    }
+    cb(err, result);
+};

--- a/app/util/nestFlightWrapper.js
+++ b/app/util/nestFlightWrapper.js
@@ -1,0 +1,22 @@
+const deleteMultiple = require('./deleteMultiple');
+
+// Make sure that nestAirportsWrapper has gone over the result before it is
+// passed to this one.
+module.exports = (cb) => function(err, result) {
+    if (err) {
+        cb(err, result);
+        return;
+    }
+    for (var record of result) {
+        record.flight = {
+            number: record.flight_number,
+            departure: record.departure,
+            destination: record.destination,
+            departureDate: record.departure_date,
+            arrivalDate: record.arrival_date
+        };
+        deleteMultiple(record, 'flight_number', 'departure', 'destination',
+            'departure_date', 'arrival_date');
+    }
+    cb(err, result);
+};

--- a/test/unit/dao/flightNumberSpec.js
+++ b/test/unit/dao/flightNumberSpec.js
@@ -12,8 +12,10 @@ describe('flightDetailDao', () => {
             flightDetailDao.get(filter, (err, result) => {
                 result.length.should.equal(1);
                 let firstEntry = result[0];
-                firstEntry.departure.should.equal('DSA');
-                firstEntry.destination.should.equal('FSE');
+                firstEntry.departure.code.should.equal('DSA');
+                firstEntry.departure.name.should.equal('test');
+                firstEntry.destination.code.should.equal('FSE');
+                firstEntry.destination.name.should.equal('test2');
                 firstEntry.departure_date.should.equal('2038-01-19 03:14:07');
                 firstEntry.arrival_date.should.equal('2038-01-20 03:14:07');
                 done();


### PR DESCRIPTION
This PR changes the queries used by various DAOs and wraps callbacks passed to them so that airports' names and codes are retrieved, not only the codes, and the caller receives them in standard `{ code: 'code', name: 'name' }` format, and similarly returns flight details (in seats) as full objects. It also fixes the test failures that the change to airport representation would have caused.

I originally made this a draft PR because I knew there might be other places where the spec says an embedded object should be returned but this backend, and thus any user-facing servers that call it, flattened into the containing scope or only returned an ID for. This turned out to be the case; I will now make the PR "ready for review" when I've added tests checking more than the number of rows returned from the database, since only the change to airport representation actually caused any tests to fail.

I'm labeling this as an "enhancement" rather than a "bug" because, while this is fixing a violation of the API spec, the API spec doesn't address the non-user-facing services at all, and the frontend has (generally) worked around such issues.